### PR TITLE
fix: add version to rebuild

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ncurses (6.4-4deepin3) unstable; urgency=medium
+
+  * Add version.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Fri, 21 Nov 2025 16:00:34 +0800
+
 ncurses (6.4-4deepin2) unstable; urgency=medium
 
   * Move lib/terminfo to /usr.


### PR DESCRIPTION
Log: The previous compilation of the LoongArch architecture had issues and did not support wide-char; a recompilation was triggered. loongarch架构之前的编译有问题，不支持wide-char，重新触发编译
Bug: 318739 324121