### PR TITLE
fix: backport CVE-2025-69720 patch for ncurses

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+ncurses (6.5+20250216-2deepin1) unstable; urgency=medium
+
+  * Backport CVE-2025-69720 patch
+    - Fix buffer overflow in infocmp analyze_string()
+    - Increase buf2 size and limit string length to
+      MAX_TERMINFO_LENGTH
+
+ -- lichenggang <lichenggang@uniontech.com>  Thu, 16 Apr 2026 20:23:48 +0800
+
 ncurses (6.5+20250216-2) unstable; urgency=medium
 
   * Update upstream signing key.

--- a/debian/patches/CVE-2025-69720.patch
+++ b/debian/patches/CVE-2025-69720.patch
@@ -1,0 +1,32 @@
+From 6f6db0e8fd14e40096a0ee6f8bdf32dedbd3fc9e Mon Sep 17 00:00:00 2001
+From: "Thomas E. Dickey" <dickey@invisible-island.net>
+Date: Sat, 13 Dec 2025 23:45:35 +0000
+Subject: [PATCH] snapshot of project "ncurses", label v6_5_20251213
+
+---
+ progs/infocmp.c                  |  5 ++++---
+ 1 files changed, 3 insertions(+), 2 deletions(-)
+ 
+diff --git a/progs/infocmp.c b/progs/infocmp.c
+index a1b2ef537..04f8f2e16 100644
+--- a/progs/infocmp.c
++++ b/progs/infocmp.c
+@@ -847,7 +847,7 @@ lookup_params(const assoc * table, char *dst, char *src)
+ static void
+ analyze_string(const char *name, const char *cap, TERMTYPE2 *tp)
+ {
+-    char buf2[MAX_TERMINFO_LENGTH];
++    char buf2[MAX_TERMINFO_LENGTH + 1];
+     const char *sp;
+     const assoc *ap;
+     int tp_lines = tp->Numbers[2];
+@@ -877,7 +877,8 @@ analyze_string(const char *name, const char *cap, TERMTYPE2 *tp)
+ 	    if (VALID_STRING(cp) &&
+ 		cp[0] != '\0' &&
+ 		cp != cap) {
+-		len = strlen(cp);
++		if ((len = strlen(cp)) > MAX_TERMINFO_LENGTH)
++		    len = MAX_TERMINFO_LENGTH;
+ 		_nc_STRNCPY(buf2, sp, len);
+ 		buf2[len] = '\0';
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 01-debian-no-ada-doc.diff
 02-debian-backspace.diff
 03-debian-ncursesconfig-omit-L.diff
+CVE-2025-69720.patch


### PR DESCRIPTION
Backport upstream fix for CVE-2025-69720 buffer overflow in progs/infocmp.c analyze_string() function
Increases buf2 size from MAX_TERMINFO_LENGTH to MAX_TERMINFO_LENGTH + 1 and limits string length copied to MAX_TERMINFO_LENGTH

Log: Backported CVE-2025-69720 fix for infocmp buffer overflow

Influence:
1. Verify infocmp tool functions correctly after patch
2. Check no regression in terminfo processing
3. Validate build succeeds with patched source

fix: 为 ncurses 合入 CVE-2025-69720 修复补丁

合入上游 CVE-2025-69720 缓冲区溢出修复补丁
修复 progs/infocmp.c 中 analyze_string() 函数的缓冲区溢出问题
将 buf2 大小从 MAX_TERMINFO_LENGTH 增加到 MAX_TERMINFO_LENGTH + 1 并限制复制的字符串长度不超过 MAX_TERMINFO_LENGTH

Log: 合入 CVE-2025-69720 修复以解决 infocmp 缓冲区溢出问题

Influence:
1. 验证 patch 应用后 infocmp 工具功能正常
2. 检查 terminfo 处理没有回归
3. 验证补丁应用后源码构建成功

repo: ncurses #master