### PR TITLE
fix(ncurses): CVE-2025-6141

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+ncurses (6.5+20250216-2deepin1.1) UNRELEASED; urgency=medium
+
+  * Non-maintainer upload.
+  * Backport CVE-2025-6141 patch
+    - Fix stack buffer overflow in postprocess_termcap()
+    - Add bounds check when copying strings in tinfo/parse_entry.c
+    - Upstream commit: 291c07deec39875f3098ecfc62eece44438649ba
+
+ -- hudeng-go <hudeng@uniontech.com>  Wed, 03 Jun 2026 14:07:49 +0800
+
 ncurses (6.5+20250216-2deepin1) unstable; urgency=medium
 
   * Backport CVE-2025-69720 patch

--- a/debian/patches/CVE-2025-6141.patch
+++ b/debian/patches/CVE-2025-6141.patch
@@ -1,0 +1,24 @@
+Description: Fix stack buffer overflow in postprocess_termcap (CVE-2025-6141)
+ When processing a crafted terminfo entry in the postprocess_termcap
+ function, the code copies strings into a fixed-size buffer without
+ bounds checking, leading to a stack-based buffer overflow.
+ The fix adds a bounds check to prevent writing past the end of the buffer.
+ .
+Origin: upstream, https://invisible-island.net/archives/ncurses/6.5/ncurses-6.5-20250329.patch.gz
+Bug-RedHat: https://bugzilla.redhat.com/show_bug.cgi?id=2373097
+Upstream-commit: 291c07deec39875f3098ecfc62eece44438649ba
+Last-Update: 2026-06-03
+---
+Index: ncurses-cve-fix/ncurses/tinfo/parse_entry.c
+===================================================================
+--- ncurses-cve-fix.orig/ncurses/tinfo/parse_entry.c
++++ ncurses-cve-fix/ncurses/tinfo/parse_entry.c
+@@ -990,6 +990,8 @@ postprocess_termcap(TERMTYPE2 *tp, bool
+ 	    bp = tp->Strings[from_ptr->nte_index];
+ 	    if (VALID_STRING(bp)) {
+ 		for (dp = buf2; *bp; bp++) {
++		    if ((size_t) (dp - buf2) >= (sizeof(buf2) - sizeof(TERMTYPE2)))
++			break;
+ 		    if (bp[0] == '$' && bp[1] == '<') {
+ 			while (*bp && *bp != '>') {
+ 			    ++bp;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@
 02-debian-backspace.diff
 03-debian-ncursesconfig-omit-L.diff
 CVE-2025-69720.patch
+CVE-2025-6141.patch


### PR DESCRIPTION
## Description

Backport upstream fix for CVE-2025-6141, a stack buffer overflow in the `postprocess_termcap()` function in `tinfo/parse_entry.c`.

When processing a crafted terminfo entry, the code copies strings into a fixed-size buffer without bounds checking, potentially allowing a local attacker to trigger a stack-based buffer overflow.

The fix adds a bounds check in the string copy loop to prevent writing past the end of the buffer.

## References

- Upstream commit: https://github.com/ThomasDickey/ncurses-snapshots/commit/291c07deec39875f3098ecfc62eece44438649ba
- Origin: ncurses 6.5-20250329 (https://invisible-island.net/archives/ncurses/6.5/ncurses-6.5-20250329.patch.gz)
- Bug-RedHat: https://bugzilla.redhat.com/show_bug.cgi?id=2373097

## Testing

All existing patches apply cleanly with `quilt push -a`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)